### PR TITLE
fix: prevent inflation and oracle manipulation attacks in waToken

### DIFF
--- a/contracts/adapters/aave/WrappedAToken.sol
+++ b/contracts/adapters/aave/WrappedAToken.sol
@@ -62,7 +62,6 @@ contract WrappedAToken is ERC20, IWrappedAToken {
 
     /// @notice Returns amount of aTokens per waToken, scaled by 1e18
     function exchangeRate() public view override returns (uint256) {
-        if (totalSupply() == 0) return WAD;
         return WAD * lendingPool.getReserveNormalizedIncome(address(underlying)) / _normalizedIncome;
     }
 

--- a/contracts/adapters/aave/WrappedAToken.sol
+++ b/contracts/adapters/aave/WrappedAToken.sol
@@ -30,7 +30,10 @@ contract WrappedAToken is ERC20, IWrappedAToken {
     /// @notice Aave lending pool
     ILendingPool public immutable override lendingPool;
 
-    /// @dev Constructor
+    /// @dev aToken's normalized income (aka interest accumulator) at the moment of waToken creation
+    uint256 private immutable _normalizedIncome;
+
+    /// @notice Constructor
     /// @param _aToken Underlying aToken
     constructor(IAToken _aToken)
         ERC20(
@@ -43,6 +46,8 @@ contract WrappedAToken is ERC20, IWrappedAToken {
         aToken = _aToken;
         underlying = IERC20(aToken.UNDERLYING_ASSET_ADDRESS());
         lendingPool = aToken.POOL();
+        _normalizedIncome = lendingPool.getReserveNormalizedIncome(address(underlying));
+        underlying.safeApprove(address(lendingPool), type(uint256).max);
     }
 
     /// @notice waToken decimals, same as underlying and aToken
@@ -57,9 +62,8 @@ contract WrappedAToken is ERC20, IWrappedAToken {
 
     /// @notice Returns amount of aTokens per waToken, scaled by 1e18
     function exchangeRate() public view override returns (uint256) {
-        uint256 supply = totalSupply();
-        if (supply == 0) return WAD;
-        return (aToken.balanceOf(address(this)) * WAD) / supply;
+        if (totalSupply() == 0) return WAD;
+        return WAD * lendingPool.getReserveNormalizedIncome(address(underlying)) / _normalizedIncome;
     }
 
     /// @notice Deposit given amount of aTokens (aToken must be approved before the call)
@@ -75,7 +79,7 @@ contract WrappedAToken is ERC20, IWrappedAToken {
     /// @return shares Amount of waTokens minted to the caller
     function depositUnderlying(uint256 assets) external override returns (uint256 shares) {
         underlying.safeTransferFrom(msg.sender, address(this), assets);
-        underlying.safeApprove(address(lendingPool), assets);
+        _ensureAllowance(assets);
         lendingPool.deposit(address(underlying), assets, address(this), 0);
         shares = _deposit(assets);
     }
@@ -108,5 +112,12 @@ contract WrappedAToken is ERC20, IWrappedAToken {
         assets = (shares * exchangeRate()) / WAD;
         _burn(msg.sender, shares);
         emit Withdraw(msg.sender, assets, shares);
+    }
+
+    /// @dev Gives lending pool max approval for underlying if it falls below `amount`
+    function _ensureAllowance(uint256 amount) internal {
+        if (underlying.allowance(address(this), address(lendingPool)) < amount) {
+            underlying.safeApprove(address(lendingPool), type(uint256).max);
+        }
     }
 }

--- a/contracts/integrations/aave/ILendingPool.sol
+++ b/contracts/integrations/aave/ILendingPool.sol
@@ -14,7 +14,6 @@ interface ILendingPool {
      *   is a different wallet
      * @param referralCode Code used to register the integrator originating the operation, for potential rewards.
      *   0 if the action is executed directly by the user, without any middle-man
-     *
      */
     function deposit(address asset, uint256 amount, address onBehalfOf, uint16 referralCode) external;
 
@@ -28,7 +27,6 @@ interface ILendingPool {
      *   wants to receive it on his own wallet, or a different address if the beneficiary is a
      *   different wallet
      * @return The final amount withdrawn
-     *
      */
     function withdraw(address asset, uint256 amount, address to) external returns (uint256);
 
@@ -36,7 +34,13 @@ interface ILendingPool {
      * @dev Returns the state and configuration of the reserve
      * @param asset The address of the underlying asset of the reserve
      * @return The state of the reserve
-     *
      */
     function getReserveData(address asset) external view returns (DataTypes.ReserveData memory);
+
+    /**
+     * @dev Returns the normalized income per unit of asset
+     * @param asset The address of the underlying asset of the reserve
+     * @return The reserve's normalized income
+     */
+    function getReserveNormalizedIncome(address asset) external view returns (uint256);
 }


### PR DESCRIPTION
The initial implementation of `WrappedAToken` used the exchange rate calculation logic similar to that of classical `ERC-4626` (divide aToken balance of wrapper contract by total shares and you're done).

This approach is known to be vulnerable to the [inflation attack](https://mixbytes.io/blog/overview-of-the-inflation-attack), and while there exist methods to mitigate it (quite tricky, by the way, because aToken is rebasing), they all don't address the oracle manipulation attack which might have even worse consequences because it also affects CAs in waToken pool:

transfer aTokens to the waToken contract -> bump exchange rate between waTokens and aTokens -> bump oracle price of waToken (product of said exchange rate and chainlink price of underlying) -> liquidate CAs in the waToken pool

The solution is based on the idea that, instead of using manipulatable balances, we can use Aave's interest rate accumulators. Define exchange rate at moment $t$ as 

$$
\frac{\text{interest accumulator}_t}{\text{interest accumulator}_0},
$$

where $t=0$ is the moment of wrapper deployment.